### PR TITLE
Update to 0.7.2

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  LACT-0.7.1.tar.gz: 1f8a147f928a776cb2c56ec3902e5bf892b211b2
-  vendor.tar.xz: 00b6f0dde3fa92c95f39747daaff74f588634d68
+  LACT-0.7.2.tar.gz: e301c7009633507bf8571d685b2a6cc1a8cdedaf
+  vendor.tar.xz: 39756240945d6f196b0f4998bf49b36247884e98

--- a/lact.spec
+++ b/lact.spec
@@ -3,7 +3,7 @@
 %define oname LACT
 
 Name:           lact
-Version:        0.7.1
+Version:        0.7.2
 Release:        1
 Summary:        Linux AMDGPU Controller
 Group:          Utility
@@ -11,6 +11,8 @@ License:        MIT
 URL:            https://github.com/ilya-zlobintsev/LACT
 Source:         https://github.com/ilya-zlobintsev/LACT/archive/v%{version}/%{oname}-%{version}.tar.gz
 Source1:        vendor.tar.xz
+# vendor.tar.xz is generated using
+# tar -xvf LACT-0.7.2.tar.gz && cargo vendor LACT-0.7.2/vendor && tar -cJf vendor.tar.xz LACT-0.7.2/vendor
 
 BuildRequires:  cargo
 BuildRequires:  rust-packaging


### PR DESCRIPTION
Just a quick update to 0.7.2 for RDNA4 support (AMD radeon 9070/9070 XT). Built, tested and installed on cooker and it works.